### PR TITLE
fix CMakeLists.txt (build error)

### DIFF
--- a/mpu6050/main/CMakeLists.txt
+++ b/mpu6050/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(COMPONENT_SRCS "mian.c")
+set(COMPONENT_SRCS "main.c")
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
 register_component()

--- a/qr/main/CMakeLists.txt
+++ b/qr/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(COMPONENT_SRCS "mian.c")
+set(COMPONENT_SRCS "main.c")
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
 register_component()

--- a/uart/main/CMakeLists.txt
+++ b/uart/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(COMPONENT_SRCS "mian.c")
+set(COMPONENT_SRCS "main.c")
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
 register_component()

--- a/wifi/wifi_ap/main/CMakeLists.txt
+++ b/wifi/wifi_ap/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(COMPONENT_SRCS "mian.c")
+set(COMPONENT_SRCS "main.c")
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
 register_component()

--- a/wifi/wifi_sta/main/CMakeLists.txt
+++ b/wifi/wifi_sta/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(COMPONENT_SRCS "mian.c")
+set(COMPONENT_SRCS "main.c")
 set(COMPONENT_ADD_INCLUDEDIRS ".")
 
 register_component()


### PR DESCRIPTION
Does not build due to a spelling error 