### PR TITLE
"ip address type mismatch" and "LEDc configuration error and camera_probe failed"

### DIFF
--- a/wifi/wifi_ap/components/esp32-camera/driver/xclk.c
+++ b/wifi/wifi_ap/components/esp32-camera/driver/xclk.c
@@ -13,13 +13,12 @@ static const char* TAG = "camera_xclk";
 
 esp_err_t camera_enable_out_clock(camera_config_t* config)
 {
-    periph_module_enable(PERIPH_LEDC_MODULE);
-
     ledc_timer_config_t timer_conf;
     timer_conf.duty_resolution = 2;
     timer_conf.freq_hz = config->xclk_freq_hz;
     timer_conf.speed_mode = LEDC_HIGH_SPEED_MODE;
     timer_conf.timer_num = config->ledc_timer;
+    timer_conf.clk_cfg = LEDC_USE_APB_CLK;
     esp_err_t err = ledc_timer_config(&timer_conf);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "ledc_timer_config failed, rc=%x", err);
@@ -39,6 +38,7 @@ esp_err_t camera_enable_out_clock(camera_config_t* config)
         ESP_LOGE(TAG, "ledc_channel_config failed, rc=%x", err);
         return err;
     }
+    periph_module_enable(PERIPH_LEDC_MODULE);
     return ESP_OK;
 }
 

--- a/wifi/wifi_ap/main/main.c
+++ b/wifi/wifi_ap/main/main.c
@@ -30,7 +30,7 @@ static const char* _STREAM_BOUNDARY = "\r\n--" PART_BOUNDARY "\r\n";
 static const char* _STREAM_PART = "Content-Type: image/jpeg\r\nContent-Length: %u\r\n\r\n";
 
 static EventGroupHandle_t s_wifi_event_group;
-static ip4_addr_t s_ip_addr;
+static esp_ip4_addr_t s_ip_addr;
 const int CONNECTED_BIT = BIT0;
 extern void led_brightness(int duty);
 static camera_config_t camera_config = {
@@ -277,7 +277,7 @@ static void wifi_init_softap()
   ESP_ERROR_CHECK(esp_wifi_start());
 
   uint8_t addr[4] = {192, 168, 4, 1};
-  s_ip_addr = *(ip4_addr_t*)&addr;
+  s_ip_addr = *(esp_ip4_addr_t*)&addr;
 
   ESP_LOGI(TAG, "wifi_init_softap finished.SSID:%s password:%s",
            ESP_WIFI_SSID, ESP_WIFI_PASS);


### PR DESCRIPTION
Fix 2 problem :
- ip address type mismatch (ip4_addr_t -> esp_ip4_addr_t)
- LEDc configuration error and camera_probe failed
   (https://github.com/espressif/esp32-camera/issues/66)

My configuration :
- module: M5Camera - B
- ESP-IDF version : V4.1
- Toolchain version: esp-2019r2
- Compiler version: 8.2.0
